### PR TITLE
Migrate to taglib 2.0

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-taglib/1.13
+taglib/2.0
 cli11/2.4.1
 
 [generators]

--- a/src/library.h
+++ b/src/library.h
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <regex>
 #include <tag.h>


### PR DESCRIPTION
This pull request is waiting for taglib 2.0 to be available on Gentoo `~arm64` and Debian `testing`: https://tracker.debian.org/pkg/taglib
https://packages.gentoo.org/packages/media-libs/taglib